### PR TITLE
add no-trailing-spaces and eol-last as warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,10 @@ module.exports = {
   "rules": {
     // Disallow Unused Variables
     "no-unused-vars": [2, {"vars": "all"}],
+    // No trailing spaces
+    "no-trailing-spaces": "warn",
+    // Line breaks at the end of files
+    "eol-last": "warn",
     // No error for unused react
     "react/jsx-uses-react": 1,
     // Prevent variables used in JSX to be marked incorrectly as unused

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-opencollective",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Base ESLint config shared across OpenCollective projects (node and browser)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
 - no-trailing-spaces: Sometimes in the course of editing files, you can end up with extra whitespace at the end of lines. These whitespace differences can be picked up by source control systems and flagged as diffs, causing frustration for developers. While this extra whitespace causes no functional issues, many code conventions require that trailing spaces be removed before check-in. https://eslint.org/docs/rules/no-trailing-spaces
- eol-last: Trailing newlines in non-empty files are a common UNIX idiom. Benefits of trailing newlines include the ability to concatenate or append to files as well as output files to the terminal without interfering with shell prompts. https://eslint.org/docs/rules/eol-last

We can then easily enforce these rules through `eslint '**/*.js' --fix`