### PR TITLE
ESLint rule proposal: lines-between-class-members

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,9 @@ module.exports = {
     // Require Following Curly Brace Conventions
     // https://eslint.org/docs/rules/curly
     curly: [1, 'all'],
+    // Require empty lines after class members
+    // https://eslint.org/docs/rules/lines-between-class-members
+    'lines-between-class-members': [1, 'always', { exceptAfterSingleLine: true }],
 
     // ---------------------------------------
     // Tweaking node/recommended configuration


### PR DESCRIPTION
Docs https://eslint.org/docs/rules/lines-between-class-members

In most places we separate class methods with a new line. I think it's a good habit because it makes a clear distinction between them and plays nice with code folding for the editors that supports it.

This PR:
- Adds **10** warnings in the frontend
- Adds **0** warning in the API

Example:
![image](https://user-images.githubusercontent.com/1556356/75964027-cc290f80-5ec6-11ea-9332-87763666887f.png)
