### PR TITLE
Rule proposal: sort-imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## How to use
 
-`npm install --save-dev eslint @babel/eslint-parser eslint-plugin-babel eslint-plugin-import eslint-plugin-node eslint-plugin-react eslint-config-opencollective`
+`npm install --save-dev eslint @babel/eslint-parser eslint-plugin-babel eslint-plugin-import eslint-plugin-node eslint-plugin-react eslint-plugin-simple-import-sort eslint-config-opencollective`
 
 Then in your ESLint config:
 

--- a/index.js
+++ b/index.js
@@ -42,6 +42,9 @@ module.exports = {
     // Adding more eslint rules as warnings
     // ------------------------------------
 
+    // Imports must be sorted
+    // https://eslint.org/docs/rules/sort-imports
+    'sort-imports': 1,
     // require at least one whitespace after comments( // and /*)
     // https://eslint.org/docs/rules/spaced-comment
     'spaced-comment': [1, 'always'],

--- a/index.js
+++ b/index.js
@@ -43,8 +43,8 @@ module.exports = {
     // ------------------------------------
 
     // Imports must be sorted
-    // https://eslint.org/docs/rules/sort-imports
-    'sort-imports': 1,
+    // https://github.com/lydell/eslint-plugin-simple-import-sort
+    'simple-import-sort/sort': 'warn',
     // require at least one whitespace after comments( // and /*)
     // https://eslint.org/docs/rules/spaced-comment
     'spaced-comment': [1, 'always'],

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-import": ">=2.25.2",
     "eslint-plugin-node": ">=11.1.0",
     "eslint-plugin-react": ">=7.26.1",
+    "eslint-plugin-simple-import-sort": ">=5.0.2",
     "husky": "^4.2.3",
     "lint-staged": "^10.0.9",
     "prettier": "^2.3.2"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "eslint-plugin-babel": ">=5.3.1",
     "eslint-plugin-import": ">=2.25.2",
     "eslint-plugin-node": ">=11.1.0",
-    "eslint-plugin-react": ">=7.26.1"
+    "eslint-plugin-react": ">=7.26.1",
+    "eslint-plugin-simple-import-sort": ">=7.0.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": ">=7.16.0",
@@ -44,7 +45,7 @@
     "eslint-plugin-import": ">=2.25.2",
     "eslint-plugin-node": ">=11.1.0",
     "eslint-plugin-react": ">=7.26.1",
-    "eslint-plugin-simple-import-sort": ">=5.0.2",
+    "eslint-plugin-simple-import-sort": ">=7.0.0",
     "husky": "^4.2.3",
     "lint-staged": "^10.0.9",
     "prettier": "^2.3.2"


### PR DESCRIPTION
We had a broken build on API because we ended up with a duplicate import after a merge (see https://github.com/opencollective/opencollective-api/pull/3609).

The [sort-imports](https://eslint.org/docs/rules/sort-imports) rule can prevent that: by having a predictable order for imports duplicates will normally result in an automatic merge or a git conflict.

**How can un-ordered imports result in a broken build**

`Base file`
```es6
import test1 from 'test1'
import test2 from 'test2'
```

`Branch 1`
```es6
import test3 from 'test3' // Add this
import test1 from 'test1'
import test2 from 'test2'
```

`Branch 2`
```es6
import test1 from 'test1'
import test2 from 'test2'
import test3 from 'test3'  // Add this
```

Merge `Branch 1` then `Branch 2` and you will end up with:
```es6
import test3 from 'test3' // Merged from Branch 1
import test1 from 'test1'
import test2 from 'test2'
import test3 from 'test3' // Merged from Branch 2

// => Babel error: duplicate test3 import
```